### PR TITLE
Fix build errors regarding missing android/key.properties file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,9 +14,11 @@ if (flutterRoot == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def keystorePropertiesFile = rootProject.file("key.properties")
 def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     compileSdkVersion 27
@@ -39,7 +41,7 @@ android {
     release {
         keyAlias keystoreProperties['keyAlias']
         keyPassword keystoreProperties['keyPassword']
-        storeFile file(keystoreProperties['storeFile'])
+        storeFile keystoreProperties.containsKey('storeFile') ? file(keystoreProperties['storeFile']) : null
         storePassword keystoreProperties['storePassword']
     }
 }


### PR DESCRIPTION
This PR fixes `flutter run` and `flutter build apk --debug` in a fresh checkout of the app, without any need to first manually edit `android/app/build.gradle` to comment out lines (#8).

See https://github.com/flutter/website/pull/1536 for more particulars.

Note that I filed this against the master branch as the develop branch was several commits behind (at least here on GitHub).
