### PR TITLE
Fixed Issue number #46. 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,6 +22,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 27
+    buildToolsVersion "23.0.1"
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
I am writing this pull request message to share my contribution to this project. I have fixed the issue number 46, which was causing build failures for some users.

As per the issue, the build was failing with an error message related to the buildToolsVersion. Upon investigating the issue, I found out that the build.gradle file was missing the required dependency for buildToolsVersion "23.0.1". I have added the missing dependency and made some other necessary changes to the file.

I have tested my changes by building the project locally and verified that it builds successfully with buildToolsVersion "23.0.1". Therefore, I am confident that my changes will resolve the issue for other users as well.

I would appreciate it if you could review my changes and merge this pull request to the master branch. Please let me know if you have any feedback or suggestions.

Thank you for your time and consideration.

Best regards,
Sanjay Kumar



